### PR TITLE
Add `esc`s to apply this macro to user-defined functions

### DIFF
--- a/src/Timeout.jl
+++ b/src/Timeout.jl
@@ -40,7 +40,7 @@ Stacktrace:
 ```
 """
 macro timeout(limit, expr)
-    :(timeout(()->$expr, $limit))
+    :(timeout(()->$(esc(expr)), $(esc(limit))))
 end
 
 export @timeout


### PR DESCRIPTION
Thank you for the useful macro!
I wanted to use it to limit the execution time of user-defined functions, so I just added `esc`s.

Without `esc`s,
```
using Timeout
function waiter(t)
    for i in 1:t
        sleep(1)
        println(i)
    end
end
@timeout 3 waiter(t)
```
resulted in `UndefVarError: waiter not defined`.

Best regards.